### PR TITLE
Support restarts on systemd based systems.

### DIFF
--- a/libexec/configure_startup_processes.sh
+++ b/libexec/configure_startup_processes.sh
@@ -64,7 +64,7 @@ for DAEMON in "${HADOOP_DAEMONS[@]}"; do
 
   # If the service relies on the existence of the GCS file cache wait for autofs
   if (( ${INSTALL_GCS_CONNECTOR} && ${ENABLE_NFS_GCS_FILE_CACHE} )) &&
-      [[ "${DEFAULT_FS}" == 'gs' ]] && [[ "${SERVICE}" != 'hdfs' ]]; then
+      [[ "${SERVICE}" != 'hdfs' ]]; then
     DEPENDENCIES+=' autofs'
   fi
 

--- a/libexec/setup_master_nfs.sh
+++ b/libexec/setup_master_nfs.sh
@@ -28,8 +28,13 @@ if (( ${INSTALL_GCS_CONNECTOR} )) && \
       "${NFS_EXPORT_POINT}" "${META_CACHE_DIRECTORY}"
 
   if ! grep -e "BDUTIL_FILE_CACHE_BINDING" /etc/fstab ; then
-    MOUNT_STRING="${META_CACHE_DIRECTORY} ${NFS_EXPORT_POINT} none bind 0 0"
-    MOUNT_STRING="${MOUNT_STRING} #BDUTIL_FILE_CACHE_BINDING"
+    MOUNT_OPTIONS='bind'
+    if which systemctl; then
+      # Use x-systemd.automount to mount after PDs on systemd based systems.
+      MOUNT_OPTIONS+=",x-systemd.automount"
+    fi
+    MOUNT_STRING="${META_CACHE_DIRECTORY} ${NFS_EXPORT_POINT}"
+    MOUNT_STRING+=" none ${MOUNT_OPTIONS} 0 0 #BDUTIL_FILE_CACHE_BINDING"
     echo "${MOUNT_STRING}" >> /etc/fstab
     mount "${NFS_EXPORT_POINT}"
   fi


### PR DESCRIPTION
A user pointed out that the master nodes running CentOS 7 did not come up after reboot.

The two causes were:
- A disk mounting race condition
- systemd's limited interpretations of LSB headers

Both are resolved here.
