### PR TITLE
Always install and enable autofs early in the install sequence.

### DIFF
--- a/bdutil_env.sh
+++ b/bdutil_env.sh
@@ -366,6 +366,7 @@ COMMAND_GROUPS=(
      libexec/install_java.sh
      libexec/mount_disks.sh
      libexec/setup_hadoop_user.sh
+     libexec/install_autofs.sh
      libexec/install_hadoop.sh
      libexec/install_bdconfig.sh
      libexec/configure_hadoop.sh

--- a/libexec/install_autofs.sh
+++ b/libexec/install_autofs.sh
@@ -1,0 +1,22 @@
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# We register autofs dependencies for Hadoop startup scripts. As a result, we
+# need autofs installed and configured to run:
+install_application "autofs"
+
+if [[ -f /usr/lib/systemd/system/autofs.service ]] \
+    && which systemctl ; then
+  systemctl enable autofs
+fi

--- a/libexec/setup_client_nfs.sh
+++ b/libexec/setup_client_nfs.sh
@@ -18,7 +18,6 @@ if (( ${INSTALL_GCS_CONNECTOR} )) && \
   setup_gcs_admin
 
   install_application "nfs-common" "nfs-utils"
-  install_application "autofs"
 
   NFS_MOUNT_POINT="$(get_nfs_mount_point)"
   NFS_EXPORT_POINT="$(get_nfs_export_point)"
@@ -32,11 +31,5 @@ if (( ${INSTALL_GCS_CONNECTOR} )) && \
   MOUNT_STRING="/${NFS_MOUNT_POINT} -fstype=nfs,defaults,rw,hard,intr"
   MOUNT_STRING="${MOUNT_STRING} ${MASTER_HOSTNAME}:${NFS_EXPORT_POINT}"
   echo "${MOUNT_STRING}" > /etc/auto.hadoop_gcs_metadata_cache
-
-  if [[ -f /usr/lib/systemd/system/autofs.service ]] \
-      && which systemctl ; then
-    systemctl enable autofs
-  fi
-
   service autofs restart
 fi

--- a/platforms/hdp/ambari_manual_env.sh
+++ b/platforms/hdp/ambari_manual_env.sh
@@ -85,6 +85,7 @@ COMMAND_GROUPS+=(
      libexec/mount_disks.sh
      libexec/install_java.sh
      libexec/setup_hadoop_user.sh
+     libexec/install_autofs.sh
      platforms/hdp/install_ambari.sh
   "
 )


### PR DESCRIPTION
AutoFS is used by the GCS connector cache and is registered as a
prerequisite for Hadoop daemon startup.
