### PR TITLE
Make sure destination directory for bdconfig exists

### DIFF
--- a/libexec/install_bdconfig.sh
+++ b/libexec/install_bdconfig.sh
@@ -19,6 +19,7 @@ set -e
 # Download and use bdconfig for xml configuration.
 if [[ ! -f "$(which bdconfig)" ]]; then
   download_bd_resource "${BDCONFIG}" /tmp/bdconfig.tar.gz
+  mkdir -p /usr/local/share/google
   tar -C /usr/local/share/google -xzf /tmp/bdconfig.tar.gz
   ln -s /usr/local/share/google/bdconfig*/bdconfig /usr/local/bin
 fi


### PR DESCRIPTION
/usr/local/share/google may not always exists for all images, images
provided by google do have this directory, but custom images may not,
thus make sure directory exists.
