### PR TITLE
Add support for Preemptible VMs.

### DIFF
--- a/bdutil
+++ b/bdutil
@@ -100,6 +100,9 @@ Flags:
     used if necessary for interacting with older existing clusters,
     as the old naming scheme is deprecated and will eventually be removed.
 
+  --preemptible
+    The fraction (between 0.0 and 1.0) of worker nodes to run as preemptible.
+
   -P, --prefix
     Common prefix for cluster nodes.
 
@@ -336,6 +339,7 @@ function prompt_confirmation() {
       GCE_IMAGE='${GCE_IMAGE?}'
       GCE_ZONE='${GCE_ZONE?}'
       GCE_NETWORK='${GCE_NETWORK?}'
+      PREEMPTIBLE_FRACTION=${PREEMPTIBLE_FRACTION?}
       PREFIX='${PREFIX?}'
       NUM_WORKERS=${NUM_WORKERS?}
       MASTER_HOSTNAME='${MASTER_HOSTNAME}'
@@ -403,6 +407,7 @@ function run_gcloud_compute_cmd() {
   # Add global flags
   gcloud_flags+=("--project=${PROJECT}")
   gcloud_flags+=('--quiet')
+
   gcloud_compute_args+=("--zone=${GCE_ZONE}")
 
   if (( ${DEBUG_MODE} )); then
@@ -465,6 +470,26 @@ function run_sanity_checks() {
     print_help
   fi
 
+  # Make sure the preemptible fraction could be a fraction
+  if [[ ! ${PREEMPTIBLE_FRACTION} =~ ^[0-1]?(\.[0-9]+)?$ ]]; then
+    logerror "Preemptible fraction '${PREEMPTIBLE_FRACTION}' not a fraction."
+    print_help
+  fi
+
+  # Make sure the preemptible fraction is in range.
+  local lt0=$(echo | awk -v x=${PREEMPTIBLE_FRACTION} '{print (x < 0) ? 1 : 0}')
+  local gt1=$(echo | awk -v x=${PREEMPTIBLE_FRACTION} '{print (x > 1) ? 1 : 0}')
+
+  if [[ $lt0 -eq 1 ]]; then
+    logerror "Preemptible fraction '${PREEMPTIBLE_FRACTION}' is less than 0.0"
+    print_help
+  fi
+
+  if [[ $gt1 -eq 1 ]]; then
+    logerror "Preemptible fraction '${PREEMPTIBLE_FRACTION}' greater than 1.0"
+    print_help
+  fi
+
   # Make sure the hostnames all abide by the PREFIX.
   local node=''
   for node in ${WORKERS[@]} ${MASTER_HOSTNAME?}; do
@@ -514,6 +539,15 @@ function run_sanity_checks() {
   if [[ "${DEFAULT_FS}" == 'hdfs' ]] && (( ! "${ENABLE_HDFS}" )); then
     logerror 'ENABLE_HDFS must 1 if DEFAULT_FS is hdfs.'
     print_help
+  fi
+
+  # Make sure preemptible is only used with gs
+  local gt0=$(echo | awk -v x=${PREEMPTIBLE_FRACTION} '{print (x > 0) ? 1 : 0}')
+  if [[ "${DEFAULT_FS}" != 'gs' ]]; then
+    if [[ "$gt0" -eq 1 ]]; then
+      logerror 'Preemptible VMs can only be used with GCS as the DEFAULT_FS.'
+      print_help
+    fi
   fi
 
   local scheme=${HADOOP_TARBALL_URI%%://*}
@@ -780,10 +814,17 @@ function create_cluster() {
           optional_disk_arg+='--local-ssd interface=SCSI '
         done
       fi
+
+      local optional_preemptible_arg=""
+      if (( ${i} < NUM_PREEMPTIBLE )); then
+        optional_preemptible_arg="--preemptible"
+      fi
+
       run_gcloud_compute_cmd \
           instances create \
            ${WORKERS[${i}]} \
           --machine-type=${GCE_MACHINE_TYPE} \
+          ${optional_preemptible_arg} \
           --image=${GCE_IMAGE} \
           --network=${GCE_NETWORK} \
           --scopes ${GCE_SERVICE_ACCOUNT_SCOPES[@]//,/ } \
@@ -1498,6 +1539,12 @@ function parse_input() {
           echo "OLD_HOSTNAME_SUFFIXES=true" >> ${OVERRIDES_FILE}
           shift
         fi
+        ;;
+      --preemptible)
+        validate_argument $1 $2
+
+        echo "PREEMPTIBLE_FRACTION=$2" >> ${OVERRIDES_FILE}
+        shift 2
         ;;
       -P|--prefix)
         validate_argument $1 $2

--- a/bdutil_env.sh
+++ b/bdutil_env.sh
@@ -48,6 +48,10 @@ GCE_NETWORK='default'
 # specified in GCE_MACHINE_TYPE.
 GCE_MASTER_MACHINE_TYPE=''
 
+# If non-zero, specifies the fraction (between 0.0 and 1.0) of worker
+# nodes that should be run as preemptible VMs.
+PREEMPTIBLE_FRACTION=0.0
+
 # Prefix to be shared by all VM instance names in the cluster, as well as for
 # SSH configuration between the JobTracker node and the TaskTracker nodes.
 PREFIX='hadoop'
@@ -329,6 +333,12 @@ function evaluate_late_variable_bindings() {
     worker_suffix='dn'
     master_suffix='nn'
   fi
+
+  # Compute NUM_PREEMPTIBLE as int(PREEMPTIBLE_FRACTION * NUM_WORKERS)
+  local frac=$PREEMPTIBLE_FRACTION
+  local n=$NUM_WORKERS
+  NUM_PREEMPTIBLE=$(echo | awk -v n1=$frac -v n2=$n '{printf("%d", n1 * n2);}')
+
   for ((i = 0; i < NUM_WORKERS; i++)); do
     WORKERS[${i}]="${PREFIX}-${worker_suffix}-${i}"
   done

--- a/conf/hadoop1/mapred-template.xml
+++ b/conf/hadoop1/mapred-template.xml
@@ -64,6 +64,16 @@
     </description>
   </property>
   <property>
+    <name>mapreduce.jobtracker.expire.trackers.interval</name>
+    <value>60000</value>
+    <description>
+      The time-interval, in milliseconds, after which a tasktracker is
+      declared 'lost' if it doesn't send heartbeats.  The Hadoop
+      distribution default is 600000 (10 minutes), we set this to
+      60000 (1 minute) to quickly reassign work.
+    </description>
+  </property>
+  <property>
     <name>mapred.local.dir</name>
     <value><envVar name="MAPRED_LOCAL_DIRS"/></value>
     <description>


### PR DESCRIPTION
Allow users to setup their cluster to have some fraction as
preemptible VMs controlled by the new --preemptible flag (valid values
are between 0.0 and 1.0).  As part of this change, we now set the
heartbeat expiration to 1 minute instead of the default of 10 minutes.

Note: running with Preemptible VMs is only safe when using GCS with
the connector, because when backed by GCS we don't rely on datanodes
(only tasknodes).  The script will emit an error if DEFAULT_FS is not
gs when PREEMPTIBLE_FRACTION is greater than 0.
