### PR TITLE
Add hadoop classpath to SPARK_DIST_CLASSPATH.

### DIFF
--- a/extensions/spark/install_spark.sh
+++ b/extensions/spark/install_spark.sh
@@ -128,7 +128,7 @@ export SPARK_DAEMON_MEMORY=${SPARK_DAEMON_MEMORY}m
 export SPARK_WORKER_DIR=${SPARK_WORKDIR}
 export SPARK_LOCAL_DIRS=${SPARK_TMPDIR}
 export SPARK_LOG_DIR=${SPARK_LOG_DIR}
-export SPARK_CLASSPATH=\$SPARK_CLASSPATH:${LOCAL_GCS_JAR}
+export SPARK_DIST_CLASSPATH+=:\$(${HADOOP_INSTALL_DIR}/bin/hadoop classpath)
 EOF
 
 # For Spark 0.9.1 and older, Spark properties must be passed in programmatically
@@ -167,7 +167,6 @@ if [[ "$(hostname -s)" == "${MASTER_HOSTNAME}" ]]; then
 fi
 
 # Misc Spark Properties that will be loaded by spark-submit.
-# TODO(user): Instead of single extraClassPath, use a lib directory.
 cat << EOF >> ${SPARK_INSTALL_DIR}/conf/spark-defaults.conf
 spark.eventLog.enabled true
 spark.eventLog.dir ${SPARK_EVENTLOG_DIR}


### PR DESCRIPTION
Remove the previous usage of SPARK_CLASSPATH for making the GCS connector
available on daemon, driver, and executor classpaths, instead inheriting
all the relevant Hadoop libraries from the Hadoop installation.
