### PR TITLE
Fix init.d setup for single-node clusters.

### DIFF
--- a/extensions/spark/spark_configure_startup_processes.sh
+++ b/extensions/spark/spark_configure_startup_processes.sh
@@ -33,7 +33,8 @@ if [[ ${SPARK_MODE} =~ ^(default|standalone)$ ]]; then
 
   if [[ "$(hostname -s)" == "${MASTER_HOSTNAME}" ]]; then
     SPARK_DAEMONS+=('master')
-  else
+  fi
+  if [[ "$(hostname -s)" != "${MASTER_HOSTNAME}" ]] || is_single_node_setup; then
     SPARK_DAEMONS+=('worker')
   fi
 

--- a/libexec/bdutil_helpers.sh
+++ b/libexec/bdutil_helpers.sh
@@ -383,3 +383,11 @@ function get_java_home() {
   sed 's|/bin/java$||' <<< ${REAL_JAVA}
 }
 
+function is_single_node_setup() {
+  if [ ${#WORKERS[@]} == 1 ] &&
+     [ "${WORKERS[0]}" == "${MASTER_HOSTNAME}" ]; then
+    true
+  else
+    false
+  fi
+}

--- a/libexec/configure_startup_processes.sh
+++ b/libexec/configure_startup_processes.sh
@@ -36,7 +36,9 @@ if [[ "$(hostname -s)" == "${MASTER_HOSTNAME}" ]]; then
   else
     HADOOP_DAEMONS+=('yarn-resourcemanager' 'mapreduce-historyserver')
   fi
-else
+fi
+
+if [[ "$(hostname -s)" != "${MASTER_HOSTNAME}" ]] || is_single_node_setup; then
   if (( ${ENABLE_HDFS} )); then
     HADOOP_DAEMONS+=('hdfs-datanode')
   fi


### PR DESCRIPTION
Extract a helper is_single_node_setup into bdutil_helpers and make the hadoop
and spark init.d setup properly detect such cases to include both master
daemons and worker daemons.
