### PR TITLE
Update Ambari's configuration to explicitly set mapreduce.job.working.dir

### DIFF
--- a/platforms/hdp/configuration.json
+++ b/platforms/hdp/configuration.json
@@ -16,6 +16,9 @@
       "hive-site" : {
         "javax.jdo.option.ConnectionPassword" : "admin"
       },
+      "mapred-site" : {
+        "mapreduce.job.working.dir" : "/user/${user.name}"
+      },
       "nagios-env" : {
         "nagios_contact" : "root@localhost"
       }


### PR DESCRIPTION
This fixes an issue with PigInputFormat trying to pass HDFS directories
to the input path's FileSystem.
