### PR TITLE
Support for Apache Hama

### DIFF
--- a/extensions/hama/README.md
+++ b/extensions/hama/README.md
@@ -1,9 +1,9 @@
 Deploying Hama on Google Compute Engine
 ===============================================
 
-Introduction
+Apache Hama
 -----------
-Apache HamaTM is a framework for Big Data analytics which uses the Bulk Synchronous Parallel (BSP) computing model, which was established in 2012 as a Top-Level Project of The Apache Software Foundation. 
+Apache Hama is a framework for Big Data analytics which uses the Bulk Synchronous Parallel (BSP) computing model, which was established in 2012 as a Top-Level Project of The Apache Software Foundation. 
 
 It provides not only pure BSP programming model but also vertex and neuron centric programming models, inspired by Google's Pregel and DistBelief.
 

--- a/extensions/hama/README.md
+++ b/extensions/hama/README.md
@@ -10,7 +10,7 @@ It provides not only pure BSP programming model but also vertex and neuron centr
 Basic Usage
 -----------
 
-Basic installation of [Apache Hama](http://hama.apache.org/) atop Hadoop on Google Cloud Platform.
+Basic installation of [Apache Hama](http://hama.apache.org/) alongside Hadoop on Google Cloud Platform.
 
     ./bdutil -e extensions/hama/hama_env.sh deploy
 

--- a/extensions/hama/README.md
+++ b/extensions/hama/README.md
@@ -1,0 +1,23 @@
+Deploying Hama on Google Compute Engine
+===============================================
+
+Introduction
+-----------
+Apache HamaTM is a framework for Big Data analytics which uses the Bulk Synchronous Parallel (BSP) computing model, which was established in 2012 as a Top-Level Project of The Apache Software Foundation. It provides not only pure BSP programming model but also vertex and neuron centric programming models, inspired by Google's Pregel and DistBelief.
+
+Basic Usage
+-----------
+
+Basic installation of [Apache Hama](http://hama.apache.org/) atop Hadoop on Google Cloud Platform.
+
+    ./bdutil -e extensions/hama/hama_env.sh deploy
+
+Or alternatively, using shorthand syntax:
+
+    ./bdutil -e hama deploy
+
+Status
+------
+
+This plugin is currently considered experimental and not officially supported.
+Contributions are welcome.

--- a/extensions/hama/README.md
+++ b/extensions/hama/README.md
@@ -3,7 +3,9 @@ Deploying Hama on Google Compute Engine
 
 Introduction
 -----------
-Apache HamaTM is a framework for Big Data analytics which uses the Bulk Synchronous Parallel (BSP) computing model, which was established in 2012 as a Top-Level Project of The Apache Software Foundation. It provides not only pure BSP programming model but also vertex and neuron centric programming models, inspired by Google's Pregel and DistBelief.
+Apache HamaTM is a framework for Big Data analytics which uses the Bulk Synchronous Parallel (BSP) computing model, which was established in 2012 as a Top-Level Project of The Apache Software Foundation. 
+
+It provides not only pure BSP programming model but also vertex and neuron centric programming models, inspired by Google's Pregel and DistBelief.
 
 Basic Usage
 -----------

--- a/extensions/hama/hama_env.sh
+++ b/extensions/hama/hama_env.sh
@@ -1,0 +1,39 @@
+# Copyright 2014 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file contains environment-variable overrides to be used in conjunction
+# with bdutil_env.sh in order to deploy a Hadoop cluster with Hama installed
+# and configured.
+# Usage: ./bdutil deploy extensions/hama/hama_env.sh.
+
+# URIs of tarball to install.
+HAMA_TARBALL_URI='gs://hama-dist/hama-dist-0.7.0.tar.gz'
+
+# Directory on each VM in which to install hama.
+HAMA_INSTALL_DIR='/home/hadoop/hama-install'
+
+COMMAND_GROUPS+=(
+  "install_hama:
+     extensions/hama/install_hama.sh
+  "
+  "start_hama:
+     extensions/hama/start_hama.sh
+  "
+)
+
+# Installation of hama on master and workers; then start_hama only on master.
+COMMAND_STEPS+=(
+  'install_hama,install_hama'
+  'start_hama,*'
+)

--- a/extensions/hama/hama_env.sh
+++ b/extensions/hama/hama_env.sh
@@ -20,6 +20,9 @@
 # URIs of tarball to install.
 HAMA_TARBALL_URI='gs://hama-dist/hama-dist-0.7.0.tar.gz'
 
+# Default Hama dist tarball requires Hadoop 2.
+import_env hadoop2_env.sh
+
 # Directory on each VM in which to install hama.
 HAMA_INSTALL_DIR='/home/hadoop/hama-install'
 

--- a/extensions/hama/install_hama.sh
+++ b/extensions/hama/install_hama.sh
@@ -1,0 +1,63 @@
+# Copyright 2014 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o nounset
+set -o errexit
+
+# Get the filename out of the full URI.
+HAMA_TARBALL=${HAMA_TARBALL_URI##*/}
+
+# Get the tarball, untar it.
+gsutil cp ${HAMA_TARBALL_URI} /home/hadoop/${HAMA_TARBALL}
+tar -C /home/hadoop -xzvf /home/hadoop/${HAMA_TARBALL}
+mv /home/hadoop/hama*/ ${HAMA_INSTALL_DIR}
+
+# Set up hama-site.xml to make sure it can access HDFS.
+cat << EOF > ${HAMA_INSTALL_DIR}/conf/hama-site.xml
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+  <property>
+    <name>bsp.master.address</name>
+    <value>${MASTER_HOSTNAME}:40000</value>
+  </property>
+  <property>
+    <name>hama.zookeeper.quorum</name>
+    <value>${MASTER_HOSTNAME}</value>
+  </property>
+  <property>
+    <name>fs.defaultFS</name>
+    <value>hdfs://${MASTER_HOSTNAME}:8020/</value>
+  </property>
+</configuration>
+EOF
+
+# Set up all workers to be groomservers.
+echo ${WORKERS[@]} | tr ' ' '\n' > ${HAMA_INSTALL_DIR}/conf/groomservers
+
+# Symlink the Hadoop hdfs-site.xml to hama's "copy" of it.
+ln -s ${HADOOP_CONF_DIR}/hdfs-site.xml ${HAMA_INSTALL_DIR}/conf/hdfs-site.xml
+
+# Explicitly set up JAVA_HOME for hama.
+JAVA_HOME=$(readlink -f $(which java) | sed 's|/bin/java$||')
+cat << EOF >> ${HBASE_INSTALL_DIR}/conf/hama-env.sh
+export JAVA_HOME=${JAVA_HOME}
+EOF
+
+# Add the hama 'bin' path to the .bashrc so that it's easy to call 'hama'
+# during interactive ssh session.
+add_to_path_at_login "${HAMA_INSTALL_DIR}/bin"
+
+# Assign ownership of everything to the 'hadoop' user.
+chown -R hadoop:hadoop /home/hadoop/ ${HAMA_INSTALL_DIR}

--- a/extensions/hama/install_hama.sh
+++ b/extensions/hama/install_hama.sh
@@ -51,7 +51,7 @@ ln -s ${HADOOP_CONF_DIR}/hdfs-site.xml ${HAMA_INSTALL_DIR}/conf/hdfs-site.xml
 
 # Explicitly set up JAVA_HOME for hama.
 JAVA_HOME=$(readlink -f $(which java) | sed 's|/bin/java$||')
-cat << EOF >> ${HBASE_INSTALL_DIR}/conf/hama-env.sh
+cat << EOF >> ${HAMA_INSTALL_DIR}/conf/hama-env.sh
 export JAVA_HOME=${JAVA_HOME}
 EOF
 

--- a/extensions/hama/start_hama.sh
+++ b/extensions/hama/start_hama.sh
@@ -1,0 +1,17 @@
+# Copyright 2014 Google Inc. All Rights Reserved.  #
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o nounset
+set -o errexit
+
+sudo -u hadoop ${HAMA_INSTALL_DIR}/bin/start-bspd.sh


### PR DESCRIPTION
This extension sets up a Apache Hama classic mode cluster atop Hadoop 1 and 2. I would be happy if you merged this because it would make bdutil an even more useful tool.
