### PR TITLE
Resolve the directory to bdutil when using symlink

### DIFF
--- a/bdutil
+++ b/bdutil
@@ -1813,7 +1813,16 @@ function main() {
   esac
 }
 
-BDUTIL_DIR="$(dirname $0)"
+# Resolve the script till it's not a symlink anymore
+BDUTIL_SCRIPT=$0
+while [ -h "$BDUTIL_SCRIPT" ]; do
+  DIR="$( cd -P "$( dirname "$BDUTIL_SCRIPT" )" && pwd )"
+  BDUTIL_SCRIPT="$(readlink "$BDUTIL_SCRIPT")"
+  [[ $BDUTIL_SCRIPT != /* ]] && BDUTIL_SCRIPT="$DIR/$BDUTIL_SCRIPT"
+done
+
+# Get the directory name of the resolved script
+BDUTIL_DIR="$(dirname $BDUTIL_SCRIPT)"
 
 # Call main function, unless running unit tests
 if [[ ! "${BDUTIL_RUN_UNIT_TEST}" ]]; then


### PR DESCRIPTION
When you unpack bdutil in a directory but have a symlink pointing to that directory ( example /usr/local/bin/bdutil -> [install_dir]/bdutil ) the script didn't find the master env script (bdutil_env.sh).

This fix will first resolve the symlink then get the real directory iso of the directory of the symlink ( example /usr/local/bin )
