### PR TITLE
Allow tuning the YARN capacity scheduler

### DIFF
--- a/conf/hadoop2/capacity-scheduler-template.xml
+++ b/conf/hadoop2/capacity-scheduler-template.xml
@@ -1,0 +1,134 @@
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+<configuration>
+
+  <property>
+    <name>yarn.scheduler.capacity.maximum-applications</name>
+    <value><envVar name="YARN_SCHEDULER_CAPACITY_MAXIMUM_APPLICATIONS"/></value>
+    <description>
+      Maximum number of applications that can be pending and running.
+    </description>
+  </property>
+
+  <property>
+    <name>yarn.scheduler.capacity.maximum-am-resource-percent</name>
+    <value><envVar name="YARN_SCHEDULER_CAPACITY_MAX_AM_PERCENT"/></value>
+    <description>
+      Maximum percent of resources in the cluster which can be used to run 
+      application masters i.e. controls number of concurrent running
+      applications.
+    </description>
+  </property>
+
+  <property>
+    <name>yarn.scheduler.capacity.resource-calculator</name>
+    <value>org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator</value>
+    <description>
+      The ResourceCalculator implementation to be used to compare 
+      Resources in the scheduler.
+      The default i.e. DefaultResourceCalculator only uses Memory while
+      DominantResourceCalculator uses dominant-resource to compare 
+      multi-dimensional resources such as Memory, CPU etc.
+    </description>
+  </property>
+
+  <property>
+    <name>yarn.scheduler.capacity.root.queues</name>
+    <value>default</value>
+    <description>
+      The queues at the this level (root is the root queue).
+    </description>
+  </property>
+
+  <property>
+    <name>yarn.scheduler.capacity.root.default.capacity</name>
+    <value>100</value>
+    <description>Default queue target capacity.</description>
+  </property>
+
+  <property>
+    <name>yarn.scheduler.capacity.root.default.user-limit-factor</name>
+    <value>1</value>
+    <description>
+      Default queue user limit a percentage from 0.0 to 1.0.
+    </description>
+  </property>
+
+  <property>
+    <name>yarn.scheduler.capacity.root.default.maximum-capacity</name>
+    <value>100</value>
+    <description>
+      The maximum capacity of the default queue. 
+    </description>
+  </property>
+
+  <property>
+    <name>yarn.scheduler.capacity.root.default.state</name>
+    <value>RUNNING</value>
+    <description>
+      The state of the default queue. State can be one of RUNNING or STOPPED.
+    </description>
+  </property>
+
+  <property>
+    <name>yarn.scheduler.capacity.root.default.acl_submit_applications</name>
+    <value>*</value>
+    <description>
+      The ACL of who can submit jobs to the default queue.
+    </description>
+  </property>
+
+  <property>
+    <name>yarn.scheduler.capacity.root.default.acl_administer_queue</name>
+    <value>*</value>
+    <description>
+      The ACL of who can administer jobs on the default queue.
+    </description>
+  </property>
+
+  <property>
+    <name>yarn.scheduler.capacity.node-locality-delay</name>
+    <value>40</value>
+    <description>
+      Number of missed scheduling opportunities after which the CapacityScheduler 
+      attempts to schedule rack-local containers. 
+      Typically this should be set to number of nodes in the cluster, By default is setting 
+      approximately number of nodes in one rack which is 40.
+    </description>
+  </property>
+
+  <property>
+    <name>yarn.scheduler.capacity.queue-mappings</name>
+    <value></value>
+    <description>
+      A list of mappings that will be used to assign jobs to queues
+      The syntax for this list is [u|g]:[name]:[queue_name][,next mapping]*
+      Typically this list will be used to map users to queues,
+      for example, u:%user:%user maps all users to queues with the same name
+      as the user.
+    </description>
+  </property>
+
+  <property>
+    <name>yarn.scheduler.capacity.queue-mappings-override.enable</name>
+    <value>false</value>
+    <description>
+      If a queue mapping is present, will it override the value specified
+      by the user? This can be used by administrators to place jobs in queues
+      that are different than the one specified by the user.
+      The default is false.
+    </description>
+  </property>
+
+</configuration>

--- a/hadoop2_env.sh
+++ b/hadoop2_env.sh
@@ -54,6 +54,10 @@ HDFS_DATA_DIRS_PERM='700'
 # 8088 for YARN, 50070 for HDFS.
 MASTER_UI_PORTS=('8088' '50070')
 
+# Allow to tune the YARN scheduler to
+YARN_SCHEDULER_CAPACITY_MAXIMUM_APPLICATIONS=10000
+YARN_SCHEDULER_CAPACITY_MAX_AM_PERCENT=0.2
+
 # Use Hadoop 2 specific configuration templates.
 if [[ -n "${BDUTIL_DIR}" ]]; then
   UPLOAD_FILES=($(find ${BDUTIL_DIR}/conf/hadoop2 -name '*template.xml'))

--- a/libexec/configure_hadoop.sh
+++ b/libexec/configure_hadoop.sh
@@ -175,3 +175,12 @@ if [[ -f yarn-template.xml ]]; then
         --clobber
   fi
 fi
+
+if [[ -f capacity-scheduler-template.xml ]]; then
+  bdconfig merge_configurations \
+      --configuration_file ${HADOOP_CONF_DIR}/capacity-scheduler.xml \
+      --source_configuration_file capacity-scheduler-template.xml \
+      --resolve_environment_variables \
+      --create_if_absent \
+      --clobber
+fi


### PR DESCRIPTION
Allows you to tune the YARN capacity scheduler (max applications and ApplicationManager percentage). This are the defaults that are set in the hadoop2_env.sh file.

```
YARN_SCHEDULER_CAPACITY_MAXIMUM_APPLICATIONS=10000
YARN_SCHEDULER_CAPACITY_MAX_AM_PERCENT=0.2
```

This is an important parameter to tune for your workload. The defaults are not ideal for small clusters: Having a cluster under the 40 vCores will only allow one ApplicationManager to run. So if you have a lot of small jobs it's better to have more jobs running concurrently, even if the cluster is small.

As an example, we run a 32 vCore cluster with  _YARN_SCHEDULER_CAPACITY_MAX_AM_PERCENT=0.6_ with good results. Having the workload managed by a workflow manager anyway (Luigi).
