### PR TITLE
Set root/default capacity of 100 to override the setting of -1 that w…

### DIFF
--- a/platforms/hdp/configuration.json
+++ b/platforms/hdp/configuration.json
@@ -1,5 +1,9 @@
 {
   "configurations" : {
+      "capacity-scheduler" : {
+        "yarn.scheduler.capacity.root.accessible-node-labels.default.capacity": "100",
+        "yarn.scheduler.capacity.root.accessible-node-labels.default.maximum-capacity": "100"
+      },
       "core-site" : {
         "fs.gs.project.id": "${PROJECT}",
         "fs.gs.system.bucket": "${CONFIGBUCKET}",


### PR DESCRIPTION
…as introduced in https://issues.apache.org/jira/browse/AMBARI-8064
