### PR TITLE
added gce tags support

### DIFF
--- a/bdutil
+++ b/bdutil
@@ -339,6 +339,7 @@ function prompt_confirmation() {
       GCE_IMAGE='${GCE_IMAGE?}'
       GCE_ZONE='${GCE_ZONE?}'
       GCE_NETWORK='${GCE_NETWORK?}'
+      GCE_TAGS='${GCE_TAGS?}'
       PREEMPTIBLE_FRACTION=${PREEMPTIBLE_FRACTION?}
       PREFIX='${PREFIX?}'
       NUM_WORKERS=${NUM_WORKERS?}
@@ -827,6 +828,7 @@ function create_cluster() {
           ${optional_preemptible_arg} \
           --image=${GCE_IMAGE} \
           --network=${GCE_NETWORK} \
+          --tags=${GCE_TAGS} \
           --scopes ${GCE_SERVICE_ACCOUNT_SCOPES[@]//,/ } \
           --boot-disk-type=pd-standard \
           ${optional_disk_arg} &
@@ -853,6 +855,7 @@ function create_cluster() {
         --machine-type=${GCE_MASTER_MACHINE_TYPE} \
         --image=${GCE_IMAGE} \
         --network=${GCE_NETWORK} \
+        --tags=${GCE_TAGS} \
         --scopes ${GCE_SERVICE_ACCOUNT_SCOPES[@]//,/ } \
         --boot-disk-type=pd-standard \
         ${optional_disk_arg} &
@@ -1524,6 +1527,11 @@ function parse_input() {
       --network)
         validate_argument $1 $2
         echo "GCE_NETWORK=$2" >> ${OVERRIDES_FILE}
+        shift 2
+        ;;
+      --tags)
+        validate_argument $1 $2
+        echo "GCE_TAGS=$2" >> ${OVERRIDES_FILE}
         shift 2
         ;;
       -n|--num_workers)

--- a/bdutil_env.sh
+++ b/bdutil_env.sh
@@ -48,6 +48,10 @@ GCE_NETWORK='default'
 # specified in GCE_MACHINE_TYPE.
 GCE_MASTER_MACHINE_TYPE=''
 
+# Specifies a comma-separated list of tags to apply to the instances for
+# identifying the instances to which network firewall rules will apply.
+GCE_TAGS=''
+
 # If non-zero, specifies the fraction (between 0.0 and 1.0) of worker
 # nodes that should be run as preemptible VMs.
 PREEMPTIBLE_FRACTION=0.0


### PR DESCRIPTION
Firewall configuration of networks other than 'default' might require instance tags in order to become ssh-able. If such a network is chosen, bdutil is able to create instances, but not ssh to them failing the deploy. This patch allows creating instances with specified instance tag(s).
