### PR TITLE
Fix instance creation error (disk space separated lists)

### DIFF
--- a/bdutil
+++ b/bdutil
@@ -804,7 +804,7 @@ function create_cluster() {
       fi
       local optional_disk_arg=''
       if (( ${USE_ATTACHED_PDS} )); then
-        optional_disk_arg+="--disk name=${WORKER_ATTACHED_PDS[${i}]} mode=rw "
+        optional_disk_arg+="--disk name=${WORKER_ATTACHED_PDS[${i}]},mode=rw "
       fi
       if (( WORKER_BOOT_DISK_SIZE_GB > 0 )); then
         optional_disk_arg+="--boot-disk-size=${WORKER_BOOT_DISK_SIZE_GB} "
@@ -837,7 +837,7 @@ function create_cluster() {
     loginfo "Creating master instance: ${MASTER_HOSTNAME}"
     local optional_disk_arg=''
     if (( ${USE_ATTACHED_PDS} )); then
-      optional_disk_arg+="--disk name=${MASTER_ATTACHED_PD} mode=rw "
+      optional_disk_arg+="--disk name=${MASTER_ATTACHED_PD},mode=rw "
     fi
     if (( MASTER_BOOT_DISK_SIZE_GB > 0 )); then
       optional_disk_arg+="--boot-disk-size=${MASTER_BOOT_DISK_SIZE_GB} "


### PR DESCRIPTION
ERROR: (gcloud.compute.instances.create) argument --disk: We noticed that you are using space-separated lists, which are deprecated. Please transition to using comma-separated lists instead (try "--disk name=clusterprefix-w-123-pd,mode=rw"). If you intend to use [mode=rw] as positional arguments, put the flags at the end.
