### PR TITLE
Updated bdutil to address new --disk argument format

### DIFF
--- a/bdutil
+++ b/bdutil
@@ -804,7 +804,7 @@ function create_cluster() {
       fi
       local optional_disk_arg=''
       if (( ${USE_ATTACHED_PDS} )); then
-        optional_disk_arg+="--disk name=${WORKER_ATTACHED_PDS[${i}]} mode=rw "
+        optional_disk_arg+="--disk name=${WORKER_ATTACHED_PDS[${i}]},mode=rw "
       fi
       if (( WORKER_BOOT_DISK_SIZE_GB > 0 )); then
         optional_disk_arg+="--boot-disk-size=${WORKER_BOOT_DISK_SIZE_GB} "


### PR DESCRIPTION
Replaced the space with a comma to address the following:

ERROR: (gcloud.compute.instances.create) argument --disk: We noticed that you are using space-separated lists, which are deprecated. Please transition to using comma-separated lists instead (try "--disk name=hadoop-w-0-pd,mode=rw"). If you intend to use [mode=rw] as positional arguments, put the flags at the end.
