### PR TITLE
gcloud requires GCE service account scopes to be comma delimited

### DIFF
--- a/bdutil
+++ b/bdutil
@@ -829,7 +829,7 @@ function create_cluster() {
           --image=${GCE_IMAGE} \
           --network=${GCE_NETWORK} \
           --tags=${GCE_TAGS} \
-          --scopes ${GCE_SERVICE_ACCOUNT_SCOPES[@]//,/ } \
+          --scopes $(export IFS=,; echo "${GCE_SERVICE_ACCOUNT_SCOPES[*]}";) \
           --boot-disk-type=pd-standard \
           ${optional_disk_arg} &
       sleep_for_api_ops
@@ -856,7 +856,7 @@ function create_cluster() {
         --image=${GCE_IMAGE} \
         --network=${GCE_NETWORK} \
         --tags=${GCE_TAGS} \
-        --scopes ${GCE_SERVICE_ACCOUNT_SCOPES[@]//,/ } \
+        --scopes $(export IFS=,; echo "${GCE_SERVICE_ACCOUNT_SCOPES[*]}";) \
         --boot-disk-type=pd-standard \
         ${optional_disk_arg} &
   else


### PR DESCRIPTION
The `gcloud compute instances create` commands are currently failing because the `--scopes` flag is receiving a space delimited list of scopes rather than a comma delimited list.  `gcloud` has been issuing a warning for months that this condition was deprecated and must have switched to an error sometime in the last few weeks.  Unless I'm missing something, `bdutil 1.3.4` cannot currently deploy a cluster with the most recent version of `gcloud`.

I'm not positive that my change is the most idiomatic `bash` way to join an array with a single character, so I'm definitely open to feedback.

As far as a CLA goes, I should be included in my employer's ([SkyTruth](skytruth.org)) CLA.

This PR switches from:

``` console
gcloud \
    instances \
    create \
    --scopes storage-full bigquery compute-rw
```

to

``` console
gcloud \
    instances \
    create \
    --scopes storage-full,bigquery,compute-rw
```

For reference, here's a sample command that was created from the changes in this PR:

``` console
gcloud \
    --project=PROJECT_ID \
    --quiet \
    --verbosity=info \
    compute \
    instances \
    create cluster-w-0
    --machine-type=n1-standard-1 \
    --image=name-2015-09-17 \
    --network=default \
    --scopes storage-full,bigquery,compute-rw \
    --boot-disk-type=pd-standard \
    --boot-disk-size=25 \
    --zone=us-central1-b
```
