### PR TITLE
Pin the version of debian-7 to backports-debian-7-wheezy-v20160531

### DIFF
--- a/bdutil_env.sh
+++ b/bdutil_env.sh
@@ -35,7 +35,7 @@ PROJECT=""
 # example, to whitelist intra-cluster SSH using the cluster prefix.
 
 # GCE settings.
-GCE_IMAGE='debian-7-backports'
+GCE_IMAGE='backports-debian-7-wheezy-v20160531'
 GCE_MACHINE_TYPE='n1-standard-4'
 GCE_ZONE=""
 # When setting a network it's important for all nodes be able to communicate


### PR DESCRIPTION
This is to immediately fix cluster creation. An upgrade to debian-8 will
be required to continue to receive bug fixes, etc.

Closes #85.
