### PR TITLE
Moving bdutil docs to GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,44 @@
 # bdutil
 
-Tools for creating Hadoop and Spark clusters on Google Compute Engine. See http://cloud.google.com/hadoop for more information.
+bdutil is a command-line script used to manage Apache Hadoop and Apache Spark instances on [Google Compute Engine](https://cloud.google.com/compute). bdutil manages deployment, configuration, and shutdown of your Hadoop instances.
+
+## Requirements
+
+bdutil depends on the [Google Cloud SDK](https://cloud.google.com/sdk). bdutil is supported in any posix-compliant Bash v3 or greater shell.
+
+## Usage
+
+See the [QUICKSTART](/docs/QUICKSTART.md) file in the `docs` directory to learn how to set up your Hadoop instances using bdutil.
+
+1. Install and configure the [Google Cloud SDK](https://cloud.google.com/sdk) if you have already not done so
+1. Clone this repository with `git clone https://github.com/GoogleCloudPlatform/bdutil.git`
+1. Modify the following variables in the bdutil_env.sh file:
+  1. `PROJECT` - Set to the project ID for all bdutil commands. The project value will be overridden in the following order (where 1 overrides 2, and 2 overrides 3):
+    * -p flag value, or if not specified then
+    * PROJECT value in bdutil_env.sh, or if not specified then
+    * gcloud default project value
+  1. `CONFIGBUCKET` - Set to a Google Compute Storage bucket that your project has read/write access to.
+1. Run `bdutil --help` for a list of commands.
+
+The script implements the following commands, which are very similar:
+
+* `bdutil create` creates and starts instances, but will not apply most configuration settings. You can call `bdutil run_command_steps` on instances afterward to apply configuration settings to them. Typically you wouldn't use this, but would use `bdutil deploy` instead.
+* `bdutil deploy` creates and starts instances with all the configuration options specified in the command line and any included configuration scripts.
+
+## Components installed
+
+The latest release of bdutil is `1.3.5`. This bdutil release installs the following versions of open source components:
+
+* Apache Hadoop - 1.2.1 (2.7.1 if you use the `-e` argument)
+* Apache Spark - 1.5.0
+* Apache Pig - 0.12
+* Apache Hive - 1.2.1
+
+## Documentation
+
+The following documentation is useful for bdutil.
+
+* **[Quickstart](/docs/QUICKSTART.md)** - A guide on how to get started with bdutil quickly.
+* **[Jobs](/docs/JOBS.md)** - How to submit jobs (work) to a bdutil cluster.
+* **[Monitoring](/docs/MONITORING.md)** - How to monitor bdutil cluster.
+* **[Shutdown](/docs/SHUTDOWN.md)** - How shutdown a bdutil cluster.

--- a/docs/JOBS.md
+++ b/docs/JOBS.md
@@ -1,0 +1,53 @@
+# Jobs
+
+Once you have [created a cluster](QUICKSTART.md) you can submit "jobs" (work) to it. These can be entirely new jobs, or jobs you port from an existing environment.
+
+## Writing Jobs
+
+To learn about how to write Hadoop jobs from the ground up, see the [Apache Hadoop tutorials](https://hadoop.apache.org/docs/current/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html).
+
+Google Cloud Platform offers input/output data connectors for your Hadoop and Spark jobs:
+
+* [Google BigQuery Connector for Hadoop](https://github.com/GoogleCloudPlatform/bigdata-interop)
+* [Google Cloud Storage Connector for Hadoop](https://github.com/GoogleCloudPlatform/bigdata-interop)
+
+## Porting existing jobs
+
+When porting a job from HDFS using the Cloud Storage connector for Hadoop, be sure to use the correct file path syntax (`gs://`).
+Also note that `FileSystem.append` is unsupported. If you choose Cloud Storage as your default file system, update your MapReduce, if necessary, to avoid using the append method.
+
+## Running jobs
+
+Once you've set up a Hadoop cluster and have written or ported a job, you can run the job using the following steps.
+
+### Validating your setup and data
+
+First, validate that your cluster is set up, and that you can access your data. Navigate to the command line to execute the following commands.
+
+Type `./bdutil shell` to SSH into the master node of the Hadoop cluster.
+Type `hadoop fs -ls .` to check the cluster status. If data outputs, the cluster is set up correctly.
+
+### Running the job
+
+Next, run the job from the command line, while you are still connected to the cluster via SSH. Always run jobs as the `hadoop` user to avoid having to type full Hadoop paths in commands.
+
+The following example runs a sample job called WordCount. Hadoop installations include this sample in the `/home/hadoop/hadoop-install/hadoop-examples-*.jar file.`
+
+To run the WordCount job:
+
+1. Navigate to the command line.
+1. Type `./bdutil shell` to SSH into the master node of the Hadoop cluster.
+1. Type `hadoop fs -mkdir input` to create the `input` directory.
+Note that when using Google Cloud Storage as your [default file system](QUICKSTART.md), input automatically resolves to `gs://$<CONFIGBUCKET>/input`.
+1. Copy any file from the web, such as the following example text from Apache, by typing the following command: `curl http://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/ClusterSetup.html > setup.html`.
+1. Copy one or more text files into the `input` directory. Using the same Apache text in the previous step, type the following command: `hadoop fs -copyFromLocal setup.html input`.
+1. Type `cd /hadoop-install/share/hadoop/mapreduce` to navigate to the Hadoop install directory.
+1. Type `hadoop jar share/hadoop/mapreduce/hadoop-*-examples-*.jar wordcount input output` to run the job on data in the input directory, and place results in the output directory.
+
+### Checking job status
+
+To check the status of of the Hadoop job, visit the [JobTracker page](http://wiki.apache.org/hadoop/JobTracker). See the [monitoring jobs](MONITORING.md) page for instructions on how to access the JobTracker.
+
+### Cleanup
+
+After completing the job, make sure to [shut down the Hadoop cluster](SHUTDOWN.md) for the most cost effective solution.

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -1,0 +1,77 @@
+# Monitoring jobs
+
+You can monitor the activity of your cluster using the Hadoop web interface while `wordcount` is running. Apache Hadoop provides web interfaces for the Hadoop Distributed File System (HDFS), MapReduce, and YARN. However, because these interfaces do not require user authentication to connect to them, they are insecure. Instead of opening these ports to public traffic, we recommend that you create a secure SSH tunnel from your local network to your [Compute Engine network](https://cloud.google.com/compute/docs/networking).
+
+## Set up a secure SSH tunnel
+
+**Google Cloud Shell** - Using the Google Cloud Shell to create an SSH tunnel is not supported and will not work. You must use a locally-installed SSH client, like PuTTY or the MacOS Terminal to create an SSH tunnel.
+
+### Option 1 (easier) - bdutil socksproxy
+You can use the command `bdutil socksproxy`. By default, this command will open a SOCKS proxy to the cluster at `localhost:1080`. You can also pass a port when opening the proxy, such as `bdutil socksproxy 8081`.
+
+Your SSH tunnel supports traffic proxying using the [SOCKS protocol](http://en.wikipedia.org/wiki/SOCKS). This means that you can send network requests through your SSH tunnel in any browser that supports the SOCKS protocol. For example, the following command allow you to open an instance of the Chrome web browser that sends network requests through the SSH tunnel.
+
+    chrome \
+      --proxy-server="socks5://localhost:1080" \
+      --host-resolver-rules="MAP * 0.0.0.0 , EXCLUDE localhost" \
+      --user-data-dir=/tmp/<hadoop-master>
+
+With this option or the one below, you can use Chrome or many other browsers.
+
+### Option 2 - gcloud compute ssh
+
+We recommend using [local port forwarding](https://www.wikipedia.org/wiki/Port_forwarding#Local_port_forwarding) to set up the SSH tunnel. Run the following to set up an SSH tunnel to the Hadoop master instance on port 1080 of your local host:
+
+    gcloud compute ssh <hadoop-master> --zone=<hadoop-master-zone> \
+      --ssh-flag="-D 1080" --ssh-flag="-N" --ssh-flag="-n"
+
+The `--ssh-flag` flag allows you to add extra parameters to your SSH connection. The `--ssh-flag` values above have the following meanings:
+
+* `-D 1080` specifies dynamic application-level port forwarding.
+* `-N` instructs the gcloud command-line tool not to open a remote shell.
+* `-n` instructs the gcloud command-line tool not to read from stdin.
+
+Using this command, your SSH tunnel operates independently from your other SSH shell sessions. By keeping the SSH tunnel independent, you can avoid both seeing tunnel-related errors in your shell output and closing your SSH tunnel by accident.
+
+The following command, as an example, will allow you to open an instance of the Chrome web browser that sends network requests through the SSH tunnel.
+
+    chrome \
+      --proxy-server="socks5://localhost:1080" \
+      --host-resolver-rules="MAP * 0.0.0.0 , EXCLUDE localhost" \
+      --user-data-dir=/tmp/<hadoop-master>
+
+This command uses the following flags:
+
+* `-proxy-server="socks5://localhost:1080"` tells Chrome to send all http:// and https:// URL requests through the SOCKS proxy server `localhost:1080`, using version 5 of the SOCKS protocol. The hostname for these URLs are resolved by the proxy server, not locally by Chrome.
+* `--host-resolver-rules="MAP * 0.0.0.0 , EXCLUDE localhost"` prevents Chrome from sending any DNS requests over the network.
+* `--user-data-dir=/tmp/<hadoop-master>` forces Chrome to open a new window that is not tied to an existing Chrome session. Without this flag, Chrome may open a new window attached to an existing Chrome session, ignoring your `--proxy-server` setting. The value set for `--user-data-dir` can be any nonexistent path.
+
+Note that the location of the `chrome` executable varies across operating systems. Common locations are as follows:
+
+| Operating System | Chrome Executable Path |
+| --- | --- |
+| Mac OS X |	`/Applications/Google Chrome.app/Contents/MacOS/Google Chrome` |
+| Linux	| `/opt/google/chrome/chrome` |
+| Windows	| `C:\Program Files (x86)\Google\Chrome\Application\chrome` |
+
+## Use the tunnel to view the Hadoop web interface
+
+After you've created a secure SSH tunnel, you can open the Hadoop MapReduce web interface (for Hadoop 1.x) or Hadoop YARN web interface (for Hadoop 2.x) in your web browser.
+
+### MapReduce web interface (Hadoop 1.x)
+
+Navigate to `http://<hadoop-master>:50030/` in your web browser to be redirected to the Hadoop Map/Reduce Administration web interface. The top portion of this page provides basic information regarding the state of your cluster.
+
+Further down on the page is a section for Running Jobs. When a MapReduce job is running, a table of running jobs with summary details about each job appears in this section. To view details about a running job, click the linked job ID in the Jobid column.
+
+After your job completes, the job appears in the Completed Jobs section of the Hadoop Map/Reduce Administration page. The Completed Jobs section will not appear until at least one job has been run.
+
+The Hadoop Map/Reduce Administration web interface does not refresh automatically. The job detail page, however, refreshes every 30 seconds.
+
+### YARN web interface (Hadoop 2.x)
+
+Navigate to `http://<hadoop-master>:8088/` to be redirected to the Hadoop All Applications web interface. The top portion of this page provides metrics regarding the application layer of your Hadoop cluster.
+
+Below this is a section for running and completed jobs. To view details about a job, click the linked job ID in the ID column. Selecting this link takes you to the application detail page. From there, you can click through to more details about the MapReduce job.
+
+The Hadoop 2.x Applications and Map/Reduce web interfaces do not refresh automatically.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,0 +1,130 @@
+# bdutil Quickstart
+
+If you want to deploy a Spark and Hadoop cluster manually, you can use `bdutil`, a command line tool, to easily deploy and manage clusters. This page describes how to configure and deploy a cluster using bdutil.
+
+You can run bdutil on any Bash v3 or later shell, either on your own machine or on a Google Compute Engine instance that you own. If you are running bdutil on a Google Compute Engine instance, you can deploy or manage a Spark or Hadoop instance in the same or a different project.
+
+## Before you begin
+
+* You must have [bdutil and gcloud installed](../README.md) on your computer or on a Google Compute Engine instance.
+* You must have write permissions to a Google Compute Engine project.
+
+## Set up your shell environment
+
+If you haven't used [`gcloud compute ssh`](https://cloud.google.com/sdk/gcloud/reference/compute/ssh) before for this project on this machine, configure `gcloud compute ssh` by following [the documentation](https://cloud.google.com/compute/docs/instances/connecting-to-instance). Make sure that the tool is configured without a passphrase. You can test your configuration by using [`gcloud compute instances create`](https://cloud.google.com/sdk/gcloud/reference/compute/instances/create) to create a new Compute Engine instance, then using `gcloud compute ssh` to connect to that instance. If you can connect to the instance, your ssh keys are properly configured. Be sure to run [`gcloud compute instances delete`](https://cloud.google.com/sdk/gcloud/reference/compute/instances/delete) after the test.
+
+**When installing software or configuring your instance, you may find it useful to log in as the `hadoop` user explicitly.**
+To switch the current user account to the `hadoop` user, run the following command:
+
+    sudo su -l hadoop
+
+If you prefer to always log in as the hadoop user, use the `--command` flag:
+
+    gcloud compute ssh --zone=<hadoop-master-zone> <hadoop-master> \
+      --ssh-flag="-t" --command="sudo su -l hadoop"
+
+## Choose a default file system
+
+You'll need to choose a default storage system for your data. The following options are available:
+
+| File system |	Description |
+| --- | --- |
+| **[Google Cloud Storage](https://cloud.google.com/storage/) [Default]**	| Google Cloud Storage is the easiest, most reliable and most cost-effective way to store large quantities of data persistently in Hadoop on Google Cloud Platform. Use the [Google Cloud Storage connector for Hadoop](https://github.com/GoogleCloudPlatform/bigdata-interop/tree/master/gcs) to connect seamlessly to Cloud Storage, either on the command-line or as part of a MapReduce. Additional benefits include interoperability with other Google services, automatic capacity scaling, and high data availability. |
+| **Hadoop Distributed File System (HDFS)** |	Hadoop Distributed File System (HDFS) is the default file system when using Apache Hadoop. While we recommend using Cloud Storage as your default, you may want to use HDFS instead if you'd like to quickly try out Hadoop on Google Cloud Platform with pre-existing jobs. HDFS is scalable across VMs, but doesn't scale per instance as well as Cloud Storage due to VM disk bandwidth limits. Data can be made persistent if you specify [persistent disk](https://cloud.google.com/compute/docs/disks/persistent-disks). It is more expensive than the other options. To make this the default storage system, change `DEFAULT_FS` in **bdutil_env.sh**. For more information, see the [Apache HDFS Users Guide](https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/HdfsUserGuide.html). |
+
+You can also enable programmatic access to [Google BigQuery](https://github.com/GoogleCloudPlatform/bigdata-interop/tree/master/bigquery).
+
+## File path syntax
+
+All *non-Hadoop-aware commands* assume local file storage for paths without any transport prefix. That means `ls /tmp/` refers to `/tmp` on your local instance drive.
+
+All *Hadoop-aware commands* assume the default Hadoop storage system — either Cloud Storage or HDFS — for paths without a transport prefix — for example, `ls /tmp` refers to `/tmp` on your command line, or `SparkContext.textFile(/tmp/)` in code, refer to a file in your default Hadoop storage system.
+
+If you need to access data for a Hadoop-aware command in the non-default file system you must fully qualify the path. Otherwise, you can use a simplified path syntax, as shown in the table below:
+
+| File location	| Cloud Storage is the default file system	| HDFS is the default file system |
+| --- | --- | --- |
+| Cloud Storage default bucket | `gs://<default_bucket>/dir/file` OR `dir/file` | `gs://<default_bucket>/dir/file` |
+| Cloud Storage non-default bucket	| `gs://<alternate bucket>/dir/file` |	`gs://<alternate bucket>/dir/file` |
+| HDFS	| `hdfs://<host>:8020/dir/file` | `hdfs://<host>:8020/dir/file` OR `hdfs:/dir/file` OR `/dir/file` |
+
+**Tip** - To determine your default Cloud Storage bucket, run one of the following commands:
+
+    hadoop org.apache.hadoop.conf.Configuration | grep fs.default
+
+    cat /home/hadoop/hadoop-install/etc/hadoop/core-site.xml | grep -A1 default
+
+## Configure your deployment
+
+**The default configuration is Hadoop 1 with Cloud Storage as the storage system.** Other configuration defaults are listed in the downloaded `bdutil_env.sh` file. To specify Hadoop 2 in `bdutil`, specify `--env_var_files hadoop2_env.sh` in your `bdutil` deployment command.
+
+The `bdutil` tool is used to deploy or stop instances. Instance settings are configured using command-line flags. However, as a convenience, we have provided shell scripts that set many of these flags and perform environment setup for useful Hadoop configurations. You can specify one or more of these shell scripts as input to bdutil to configure your environment. The setup package includes the following configuration files:
+
+* **`bdutil_env.sh`** The base configuration. It is always run by bdutil; you do not need to specify it. Modify this script to apply your specific project and base configuration details.
+single_node_env.sh Deploys a pseudo-distributed cluster with all of the required Hadoop components running on a single VM.
+* **`hadoop2_env.sh`** Deploys a cluster with the [latest stable version of Hadoop 2.x](http://hadoop.apache.org/docs/current/) instead of the traditional Hadoop 1.x version.
+* **`bigquery_env.sh`** Deploys a cluster with the [BigQuery connector](https://github.com/GoogleCloudPlatform/bigdata-interop/tree/master/bigquery) for Hadoop installed. Not compatible with hadoop2_env.sh.
+* **`extensions/querytools/querytools_env.sh`** Deploys a cluster with [Apache Pig](http://pig.apache.org) and [Apache Hive](http://hive.apache.org) installed. Not compatible with `hadoop2_env.sh`.
+* **`extensions/spark/spark_env.sh`** Deploys a cluster with [Apache Spark](http://spark.apache.org) installed.
+
+Specify one or more of the above configuration files using the `--env_var_files` flag. Do not specify the base `bdutil_env.sh` script, which is always run. For example, the following command deploys a 5-worker cluster (`-n 5`) with the prefix `my-cluster`, assigning the default Cloud Storage bucket to be `foo-bucket`, with BigQuery connector Hive, and Pig on each instance.
+
+    ./bdutil --bucket foo-bucket -n 5 -P my-cluster \
+       --env_var_files bigquery_env.sh,querytools_env.sh deploy
+
+If you pass in multiple files, values in later files override values in earlier files if the values conflict.
+
+Run `./bdutil --help` for documentation and examples of running the tool to configure, deploy, or delete your instance.
+
+You can save your common flag settings in a custom config file using the `--generate_config` command. Run `./bdutil --help` for an example.
+
+### Writing custom environment variable configuration files
+
+You can also write custom configuration files. The following table describes important environment variables that you may want to specify.
+
+| Environment variable	| Description | Default |
+| --- | --- | --- |
+| `CONFIGBUCKET` | A required variable that must either be set before running the setup script or at runtime using the `--bucket` (even if you don't plan to use Google Cloud Storage as your default file system.) This environment variable specifies the Cloud Storage bucket that is used for sharing generated SSH keys and configuration values. The Cloud Platform PROJECT specified, must have Can edit permissions to the bucket. For more information about service accounts, see [Authenticating From Google Compute Engine](https://cloud.google.com/compute/docs/authentication#whatis). In the event no project is specified in bdutil_env.sh or using the --project flag at runtime, then the default project configured with gcloud will be used, see [Managing authentication and credentials with gcloud](https://cloud.google.com/sdk/gcloud/#gcloud.auth). | None. |
+| `PROJECT` | The Google Cloud Platform project ID that the setup script uses to create Google [Compute Engine instances](https://cloud.google.com/compute/docs/instances). If not specified, this configuration variable is set to the [default project ID](https://cloud.google.com/sdk/gcloud/#gcloud.auth) used by gcloud. | Default project ID. |
+| `DEFAULT_FS` | The default file system for the Hadoop cluster. Set `hdfs` for HDFS, and `gs` for Cloud Storage. | `gs` |
+| `GCE_MACHINE_TYPE` | The [machine type](https://cloud.google.com/compute/docs/instances) of the Google Compute Engine instance. Each node in the Hadoop cluster is set to this machine type. | `n1-standard-4` |
+| `GCE_ZONE` | The [zone](https://cloud.google.com/compute/docs/zones) of the Google Compute Engine instance. Each node in the Hadoop cluster is set to this zone. This value may need to be updated occasionally due to [scheduled zone maintenance windows](https://cloud.google.com/compute/docs/zones#maintenance). | `us-central1-a` |
+| `GCE_SERVICE_ACCOUNT_SCOPES` |  The comma-separated list of [Service-Account scopes](https://cloud.google.com/compute/docs/authentication) to enable for your instances. `storage-full` is a required scope value for gsutil and the [Google Cloud Storage connector for Hadoop](https://github.com/GoogleCloudPlatform/bigdata-interop/tree/master/gcs). | `storage-full` |
+| `HADOOP_TARBALL_URI` |  The URI of the Hadoop tarball to be deployed on the cluster. The value must begin with `gs://` or `http(s)://` and can be any URI source that contains a 1 file, such as an Apache mirror or your own Cloud Storage bucket. Supported tarballs include `hadoop-1.2.1-bin.tar.gz` and `hadoop-2.4.1.tar.gz`. To use Hadoop 2.X, copy or edit `hadoop2_env.sh` instead of relying on this variable since there are significant setup differences between Hadoop 1.x and Hadoop 2.x. | `gs://hadoop-dist/hadoop-1.2.1-bin.tar.gz` |
+| `JAVAOPTS` | Options that TaskTracker nodes use when creating child JVM processes. For more information about these options, see Task Execution & Environment. | `-Xms1024m -Xmx2048m` |
+| `NUM_WORKERS` | The number of worker nodes in the Hadoop cluster. | `2` |
+| `PREFIX` | The prefix that [Google Compute Engine](https://cloud.google.com/compute/) appends to each [instance name](https://cloud.google.com/compute/docs/instances) in the Hadoop cluster. | `hs-ghfs` |
+| `ENABLE_HDFS` | Controls whether or not to configure and start HDFS on the deployed cluster. This value must be set to `true` if `DEFAULT_FS` is set to hdfs. | `true` |
+| `USE_ATTACHED_PDS` | Indicates if a [persistent disk](https://cloud.google.com/compute/docs/disks/persistent-disks#attach_disk) should be created and attached to each [instance](https://cloud.google.com/compute/docs/instances) in the Hadoop cluster. The related `CREATE_ATTACHED_PDS_ON_DEPLOY` property controls if `bdutil` will first create the persistent disk. After the persistent disk is optionally created, bdutil attaches the persistent disk to the instance by using the `gcloud compute instances create` command. By default, the persistent disk name is the instance name, followed by a `-pd` suffix. | `false` |
+| `CREATE_ATTACHED_PDS_ON_DEPLOY` | Indicates if `bdutil` should create a persistent disk for the instance. If `CREATE_ATTACHED_PDS_ON_DEPLOY` is set to `true`, bdutil creates a non-root persistent disk by calling `gcloud compute instances create`. If `false`, bdutil assumes that the persistent disk exists and does not need to be created. This property is only used if the `USE_ATTACHED_PDS property` is set to `true`. | `true` |
+| `DELETE_ATTACHED_PDS_ON_DELETE` | Indicates if the persistent disk should be deleted when the [cluster shuts down](SHUTDOWN.md). This property is only used if the `USE_ATTACHED_PDS` property is set to `true`. If you want to persist HDFS data between cluster deployments, set this property to `false` **before shutting down the cluster**, and set `CREATE_ATTACHED_PDS_ON_DEPLOY` to `false` the next time you deploy the same instance name. | `true` |
+| `WORKER_ATTACHED_PDS_SIZE_GB` | Specifies the size in GB of the persistent disk that will be attached to each worker node instance. This property is only used if `USE_ATTACHED_PDS` is set to `true` and `CREATE_ATTACHED_PDS_ON_DEPLOY` is set to `true`. | `500` |
+| `NAMENODE_ATTACHED_PD_SIZE_GB` | Specifies the size in GB of the persistent disk that will be attached to each name node instance. This property is only used if `USE_ATTACHED_PDS` is set to `true` and `CREATE_ATTACHED_PDS_ON_DEPLOY` is set to `true`. | `500` |
+
+### Deploy your instances
+
+Navigate to the the `bdutil-*` directory on the command line, then type the following:
+
+    ./bdutil deploy --bucket <configuration-bucket> <any other flags>
+
+#### For example:
+
+    ./bdutil --bucket foo-bucket -n 5 -P my-cluster \
+      --env_var_files bigquery_env.sh,datastore_env.sh deploy
+
+Deployment can take a few minutes. The script prints "Deployment complete" on the command line when the cluster is up.
+
+You are currently limited to a single master per Hadoop cluster on Google Compute Engine. When using bdutil you can add multiple clusters to a project.
+
+When you deploy a Hadoop machine, the Hadoop software is installed under `/home/hadoop`. All users who can SSH into the Hadoop master will have all of the necessary Hadoop-related variables set in their shell environment automatically. This means you can run Hadoop jobs with no additional configuration. .
+
+### Is an instance a master or worker?
+
+By default, workers are named `hadoop-w-****` and masters are named `hadoop-m-****`. On the command line, run gcloud [`compute instances describe <instance_name>`](https://cloud.google.com/sdk/gcloud/reference/compute/instances/describe) which may display tags indicating the role of an instance.
+
+## Troubleshooting deployment
+
+During deployment, `bdutil` runs remote setup commands with **stdout** and **stderr** piped into files on the instances. You can view these files for debugging purposes by:
+
+1. Using `gcloud compute ssh` to log into the instance
+1. Navigating to your home directory, then viewing the `*.stderr` and `*.stdout` files or uploading the files to Cloud Storage.

--- a/docs/SHUTDOWN.md
+++ b/docs/SHUTDOWN.md
@@ -1,0 +1,41 @@
+# Shutting Down a Hadoop Cluster
+
+Because [Google Compute Engine](https://cloud.google.com/compute/) charges on a [per-minute basis](https://cloud.google.com/compute/pricing), it can be cost effective to shut down your Hadoop cluster once a workload completes. Once the Hadoop cluster is shut down, your data's accessibility depends on the [default file system](QUICKSTART.md) you've chosen:
+
+* When using HDFS, data is inaccessible.
+* When using [Google Cloud Storage](https://cloud.google.com/storage/), data is accessible with [gsutil](https://cloud.google.com/storage/docs/gsutil) or the [Google Cloud Platform Console](https://console.cloud.google.com/?_ga=1.81149463.169096153.1475769191).
+
+**When you delete (shutdown) a cluster, the operation is irreversible.**
+
+## Issuing the delete command
+
+To shut down the Hadoop cluster, use the bdutil file included as part of the setup script. Type `./bdutil delete` in the `bdutil-<version>` directory on the command line to shut down the cluster.
+
+Here is an example of the command being run.
+
+    ~/bdutil-0.35.1$ ./bdutil delete
+    Wed Aug 13 16:03:15 PDT 2014: Using local tmp dir for staging files: /tmp/bdutil-20140813-160315
+    Wed Aug 13 16:03:15 PDT 2014: Using custom environment-variable file(s): ./bdutil_env.sh
+    Wed Aug 13 16:03:15 PDT 2014: Reading environment-variable file: ./bdutil_env.sh
+    Delete cluster with following settings?
+          CONFIGBUCKET='<CONFIGBUCKET>'
+          PROJECT='<PROJECT>'
+          GCE_IMAGE='backports-debian-7'
+          GCE_ZONE='us-central1-b'
+          GCE_NETWORK='default'
+          PREFIX='hadoop'
+          NUM_WORKERS=2
+          MASTER_HOSTNAME='hadoop-m'
+          WORKERS='hadoop-w-0 hadoop-w-1'
+          BDUTIL_GCS_STAGING_DIR='gs://<CONFIGBUCKET>/bdutil-staging/hadoop-m'
+          (y/n) y
+    Wed Aug 13 16:03:16 PDT 2014: Deleting hadoop cluster...
+    ...Wed Aug 13 16:03:17 PDT 2014: Waiting on async 'deleteinstance' jobs to finish. Might take a while...
+    ...
+    Wed Aug 13 16:04:11 PDT 2014: Done deleting VMs!
+    Wed Aug 13 16:04:11 PDT 2014: Execution complete. Cleaning up temporary files...
+    Wed Aug 13 16:04:11 PDT 2014: Cleanup complete.
+
+## Verifying all resources have been removed
+
+You **must** use the same bdutil configuration arguments for cluster creation and deletion. Altering the arguments might result in errors when shutting down the cluster. After the script executes, you can type `gcloud compute instances list --project=<PROJECT> | grep <PREFIX>` and verify that no instances are still running. Similarly, you can type `gcloud compute disks list --project=<PROJECT> | grep <PREFIX>` and verify that no created disks accidentally survived.


### PR DESCRIPTION
Moving the bdutil docs from cloud.google.com/hadoop to the GitHub repo
so they can live alongside bdutil.

(squashed commits)
Fixes for typos and other issues in the first pass.

Fixes, round 2