### PR TITLE
libsnappy1 has been replaced and jdk updated for debian 9

### DIFF
--- a/libexec/configure_startup_processes.sh
+++ b/libexec/configure_startup_processes.sh
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 # Populates /etc/init.d scripts to keep processes up on startup
+apt-get install -y sysv-rc-conf
 
 set -e
 

--- a/libexec/install_hadoop.sh
+++ b/libexec/install_hadoop.sh
@@ -19,7 +19,7 @@
 set -e
 
 # Install Snappy native libs first:
-install_application "libsnappy1" "snappy"
+install_application "libsnappy1v5" "snappy"
 install_application "libsnappy-dev" "snappy-devel"
 
 # We'll use this to get architecture information later

--- a/libexec/install_java.sh
+++ b/libexec/install_java.sh
@@ -20,8 +20,8 @@
 
 if (( ${INSTALL_JDK_DEVEL} )); then
   echo 'Installing JDK with compiler and tools'
-  install_application "openjdk-7-jdk" "java-1.7.0-openjdk-devel"
+  install_application "openjdk-11-jdk" "java-1.11.0-openjdk-devel"
 else
   echo 'Installing minimal JRE'
-  install_application "openjdk-7-jre-headless" "java-1.7.0-openjdk"
+  install_application "openjdk-11-jre-headless" "java-1.11.0-openjdk"
 fi


### PR DESCRIPTION
libsnappy1 has been replaced with libsnappy1v5 in Debian 9 Stretch and JDK version must be up to date to 11.